### PR TITLE
Patch/slideshow scaling

### DIFF
--- a/src/components/SlideShow.astro
+++ b/src/components/SlideShow.astro
@@ -17,14 +17,15 @@ shuffleArray(images);
 
 <div class="h-full">
   <slide-image class="block w-full h-full">
-    <div class="w-full h-full overflow-hidden grid">
+    <div class="relative w-full h-full">
       {
         images.map((i) => (
-          <img
-            class="transition-opacity duration-1000 ease-in-out opacity-0  w-full h-full object-contain"
-            style="grid-area: 1/1/2/2;"
-            src={i.default.src}
-          />
+          <div class="absolute top-0 bottom-0 left-0 right-0">
+            <img
+              class="transition-opacity duration-1000 ease-in-out opacity-0 w-full h-full object-contain"
+              src={i.default.src}
+            />
+          </div>
         ))
       }
     </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -41,7 +41,7 @@ const { title } = Astro.props;
             <Sidebar />
           </div>
           <div class="flex-1 w-full px-4 pt-6 h-full">
-            <div class="overflow-y-scroll h-full pr-3 pb-24">
+            <div class="overflow-y-scroll h-full pr-3 pb-8">
               <slot />
             </div>
           </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,7 +6,7 @@ import Layout from "@layouts/Layout.astro";
 <Layout title="Overview">
   <div class="flex flex-col h-full">
     <div class="flex-none">
-      <p class="text-sm leading-tight text-justify mb-16">
+      <p class="text-sm leading-tight text-justify mb-8">
         The Laboratory of Computational Proteomics headed by David Fenyö has as
         its research goal the detailed understanding of the dynamics of cellular
         processes. The lab applies mathematical statistical and computational


### PR DESCRIPTION
This fixes sizing issues when using the Chrome browser. The images in the slideshow were not sized to the container, as the grid area does not work correctly when calculating spacing.

+ Use absolute positioning to overlap the images and add a wrapper div to allow the absolute element to use the full space
+ Adjust page margins to be smaller
+ Make the space between the slideshow and paragraph smaller