### PR TITLE
fix: member card layout

### DIFF
--- a/src/components/CardGroup.astro
+++ b/src/components/CardGroup.astro
@@ -1,0 +1,39 @@
+---
+import MemberCard from "@components/MemberCard.astro";
+
+interface Member {
+  image: string;
+  firstName: string;
+  lastName: string;
+  position: string;
+  suffix?: string;
+  projectDesc?: string;
+  summary?: boolean;
+}
+
+interface Props {
+  group: string;
+  members: Member[];
+  summary: boolean;
+}
+
+const { group, members, summary = false } = Astro.props;
+---
+
+{
+  (
+    <>
+      <li class="font-bold my-4">{group}</li>
+      <ul
+        class:list={[
+          "list-none",
+          summary ? "flex flex-wrap gap-4 items-stretch" : "space-y-8",
+        ]}
+      >
+        {members.map((member: Member) => (
+          <MemberCard {...member} summary={summary} />
+        ))}
+      </ul>
+    </>
+  )
+}

--- a/src/pages/alumni.astro
+++ b/src/pages/alumni.astro
@@ -1,7 +1,7 @@
 ---
-import MemberCard from "@components/MemberCard.astro";
 import Layout from "@layouts/Layout.astro";
 
+import CardGroup from "@components/CardGroup.astro";
 import alumni from "@data/alumni.json";
 
 interface Member {
@@ -21,16 +21,13 @@ interface Member {
       class="pl-2 font-bold underline">Alumni</a
     >
   </div>
-  {
-    Object.entries(alumni).map(([group, members]) => (
-      <ul class="list-none mb-8">
-        <li class="font-bold">{group}</li>
-        <ul class="list-none flex flex-wrap gap-4 items-stretch">
-          {members.map((member: Member) => (
-            <MemberCard summary={true} {...member} />
-          ))}
-        </ul>
-      </ul>
-    ))
-  }
+  <ul class="list-none mb-8">
+    {
+      Object.entries(alumni).map(([group, members]) => (
+        <>
+          <CardGroup group={group} members={members} summary={true} />
+        </>
+      ))
+    }
+  </ul>
 </Layout>

--- a/src/pages/members.astro
+++ b/src/pages/members.astro
@@ -1,17 +1,12 @@
 ---
-import MemberCard from "@components/MemberCard.astro";
+import CardGroup from "@components/CardGroup.astro";
 import Layout from "@layouts/Layout.astro";
 
-import members from "@data/members.json";
+import groups from "@data/members.json";
 
-interface Member {
-  image: string;
-  firstName: string;
-  lastName: string;
-  position: string;
-  suffix?: string;
-  email?: string;
-}
+const summarize = [
+  "Interns / Visitors / Rotation Students / Master's Students",
+];
 ---
 
 <Layout title="Members">
@@ -23,14 +18,13 @@ interface Member {
   </div>
   <ul class="list-none mb-8">
     {
-      Object.entries(members).map(([group, members]) => (
+      Object.entries(groups).map(([group, members]) => (
         <>
-          <li class="font-bold my-4">{group}</li>
-          <ul class="list-none space-y-8">
-            {members.map((member: Member) => (
-              <MemberCard {...member} />
-            ))}
-          </ul>
+          <CardGroup
+            group={group}
+            members={members}
+            summary={summarize.includes(group)}
+          />
         </>
       ))
     }


### PR DESCRIPTION
+ make interns etc use the summary layout
+ add cardgroup to simplify specifying summary layout for a group
+ add a list to track what member groups should be summarized